### PR TITLE
Quelques ajouts d'options dans PanelPlot

### DIFF
--- a/src/MNHPy/Panel_Plot.py
+++ b/src/MNHPy/Panel_Plot.py
@@ -691,6 +691,7 @@ class PanelPlot():
             if colorbar:
                 cb = plt.colorbar(
                     cf,
+                    extend='both', 
                     ax=self.ax[iax],
                     fraction=0.031,
                     pad=self.colorbarpad,

--- a/src/MNHPy/Panel_Plot.py
+++ b/src/MNHPy/Panel_Plot.py
@@ -793,12 +793,14 @@ class PanelPlot():
             axeX = Lxx[i]
             axeY = Lyy[i]
             if Lxx[i].ndim == 2:
-                cf = self.ax[iax].quiver(axeX[::Larrowstep[i], ::Larrowstep[i]], axeY[::Larrowstep[i], ::Larrowstep[i]],
-                                         vartoPlot1[::Larrowstep[i], ::Larrowstep[i]], vartoPlot2[::Larrowstep[i], ::Larrowstep[i]],
+                print('yooo')
+                cf = self.ax[iax].quiver(axeX[::Larrowstep2[i], ::Larrowstep[i]], axeY[::Larrowstep2[i], ::Larrowstep[i]],
+                                         vartoPlot1[::Larrowstep[i], ::Larrowstep2[i]], vartoPlot2[::Larrowstep[i], ::Larrowstep2[i]],
                                          width=Lwidth[i], angles='uv', color=Lcolor[i], scale=Lscale[i])
             else:
-                cf = self.ax[iax].quiver(axeX[::Larrowstep[i]], axeY[::Larrowstep[i]],
-                                         vartoPlot1[::Larrowstep[i], ::Larrowstep[i]], vartoPlot2[::Larrowstep[i], ::Larrowstep[i]],
+                print('yaaa')
+                cf = self.ax[iax].quiver(axeX[::Larrowstep2[i]], axeY[::Larrowstep[i]],
+                                         vartoPlot1[::Larrowstep[i], ::Larrowstep2[i]], vartoPlot2[::Larrowstep[i], ::Larrowstep2[i]],
                                          width=Lwidth[i], angles='uv', color=Lcolor[i], scale=Lscale[i])
             #  Title
             self.set_Title(self.ax, iax, Ltitle[i], Lid_overlap, Lxlab[i], Lylab[i])

--- a/src/MNHPy/Panel_Plot.py
+++ b/src/MNHPy/Panel_Plot.py
@@ -389,6 +389,7 @@ class PanelPlot():
             if colorbar:
                 cb = plt.colorbar(
                     cf,
+                    extend='both',
                     ax=self.ax[iax],
                     fraction=0.031,
                     pad=self.colorbarpad,

--- a/src/MNHPy/Panel_Plot.py
+++ b/src/MNHPy/Panel_Plot.py
@@ -228,9 +228,9 @@ class PanelPlot():
         self.ax[self.i].text(0.0, self.timepad, strtext, verticalalignment='top', horizontalalignment='left',
                              transform=self.ax[self.i].transAxes, color='black', fontsize=self.timeSize)
 
-    def psectionV(self, Lxx=[], Lzz=[], Lvar=[], Lxlab=[], Lylab=[], Ltitle=[], Lminval=[], Lmaxval=[],
+        def psectionV(self, Lxx=[], Lzz=[], Lvar=[], Lxlab=[], Lylab=[], Ltitle=[], Lminval=[], Lmaxval=[],
                   Lstep=[], Lstepticks=[], Lcolormap=[], Lcbarlabel=[], LcolorLine=[], Lcbformatlabel=[], Llinewidth=[],
-                  Lfacconv=[], ax=[], Lid_overlap=[], colorbar=True, orog=[], Lxlim=[], Lylim=[], Ltime=[], Lpltype=[], LaddWhite_cm=[], LwhiteTop=[]):
+                  Lfacconv=[], ax=[], Lid_overlap=[], colorbar=True, orog=[], Lxlim=[], Lylim=[], Ltime=[], Lpltype=[], LaddWhite_cm=[], LwhiteTop=[], Lextendcolorbar=[]):
         """
           Vertical cross section plot
           Parameters :
@@ -260,6 +260,7 @@ class PanelPlot():
               - LwhiteTop    : List of boolean to add the white color at the first top (high value). If false, the white is added at the bottom if Laddwhite_cm=T
               - Lcbformatlabel: List of boolean to reduce the format to exponential 1.1E+02 format colorbar label
               - orog         : Orography variable
+              - Lextendcolorbar : List of boolean to extend the colorbar in both directions
         """
         self.ax = ax
         firstCall = (len(self.ax) == 0)
@@ -291,6 +292,8 @@ class PanelPlot():
             Lcbformatlabel = [False] * len(Lvar)
         if not Llinewidth:
             Llinewidth = [1.0] * len(Lvar)
+        if not Lextendcolorbar: 
+            Lextendcolorbar = [False] * len(Lvar)
 
         #  Add an extra percentage of the top max value for forcing the colorbar show the true user maximum value (correct a bug)
         Lmaxval = list(map(lambda x, y: x + 1E-6 * y, Lmaxval, Lstep))  # The extra value is 1E-6 times the step ticks of the colorbar
@@ -331,6 +334,7 @@ class PanelPlot():
 
             #  Plot
             if Lpltype[i] == 'c':  # Contour
+                print('contour simple')
                 if LcolorLine:
                     cf = self.ax[iax].contour(Lxx[i], Lzz[i], var * Lfacconv[i], levels=levels_contour,
                                               norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], colors=LcolorLine[i], linewidths=Llinewidth[i])
@@ -338,9 +342,13 @@ class PanelPlot():
                     cf = self.ax[iax].contour(Lxx[i], Lzz[i], var * Lfacconv[i], levels=levels_contour,
                                               norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i], linewidths=Llinewidth[i])
             else:  # Contourf
-                cf = self.ax[iax].contourf(Lxx[i], Lzz[i], var * Lfacconv[i], levels=levels_contour,
+                if Lextendcolorbar[i]: 
+                    cf = self.ax[iax].contourf(Lxx[i], Lzz[i], var * Lfacconv[i], levels=levels_contour,
+                                           norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i], extend='both')
+                else: 
+                    cf = self.ax[iax].contourf(Lxx[i], Lzz[i], var * Lfacconv[i], levels=levels_contour,
                                            norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i])
-
+                        
             #  Title
             self.set_Title(self.ax, iax, Ltitle[i], Lid_overlap, Lxlab[i], Lylab[i])
 
@@ -389,7 +397,6 @@ class PanelPlot():
             if colorbar:
                 cb = plt.colorbar(
                     cf,
-                    extend='both',
                     ax=self.ax[iax],
                     fraction=0.031,
                     pad=self.colorbarpad,
@@ -521,7 +528,7 @@ class PanelPlot():
 
     def psectionH(self, lon=[], lat=[], Lvar=[], Lcarte=[], Llevel=[], Lxlab=[], Lylab=[], Ltitle=[], Lminval=[], Lmaxval=[],
                   Lstep=[], Lstepticks=[], Lcolormap=[], LcolorLine=[], Lcbarlabel=[], Lproj=[], Lfacconv=[], coastLines=True, ax=[],
-                  Lid_overlap=[], colorbar=True, Ltime=[], LaddWhite_cm=[], LwhiteTop=[], Lpltype=[], Lcbformatlabel=[], Llinewidth=[]):
+                  Lid_overlap=[], colorbar=True, Ltime=[], LaddWhite_cm=[], LwhiteTop=[], Lpltype=[], Lcbformatlabel=[], Llinewidth=[], Lextendcolorbar=[]):
         """
           Horizontal cross section plot
           Parameters :
@@ -552,6 +559,8 @@ class PanelPlot():
               - LaddWhite_cm : List of boolean to add white color to a colormap at the first (low value) tick colorbar
               - LwhiteTop    : List of boolean to add the white color at the first top (high value). If false, the white is added at the bottom if Laddwhite_cm=T
               - Lcbformatlabel: List of boolean to reduce the format to exponential 1.1E+02 format colorbar label
+              - Lextendcolorbar : List of boolean to extend the colorbar in both directions
+
         """
         self.ax = ax
         firstCall = (len(self.ax) == 0)
@@ -583,6 +592,8 @@ class PanelPlot():
             Lcbformatlabel = [False] * len(Lvar)
         if not Llinewidth:
             Llinewidth = [1.0] * len(Lvar)
+        if not Lextendcolorbar: 
+            Lextendcolorbar = [False] * len(Lvar)
 
         #  Add an extra percentage of the top max value for forcing the colorbar show the true user maximum value (correct a bug)
         if Lstep:
@@ -654,14 +665,22 @@ class PanelPlot():
                         cf = self.ax[iax].contour(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour, transform=Lproj[i],
                                                   norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i],linewidths=Llinewidth[i])
                 else:
-                    cf = self.ax[iax].contourf(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour, transform=Lproj[i],
+                    if Lextendcolorbar[i]: 
+                        cf = self.ax[iax].contourf(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour, transform=Lproj[i],
+                                               norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i], extend='both')
+                    else: 
+                        cf = self.ax[iax].contourf(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour, transform=Lproj[i],
                                                norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i])
             else:  # Cartesian coordinates
                 if Lpltype[i] == 'c':  # Contour
-                    cf = self.ax[iax].contour(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour,
+                    cf = self.ax[iax].contour(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour, extend='both',
                                               norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], colors=LcolorLine[i],linewidths=Llinewidth[i])
                 else:
-                    cf = self.ax[iax].contourf(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour,
+                    if Lextendcolorbar[i]: 
+                        cf = self.ax[iax].contourf(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour, transform=Lproj[i],
+                                               norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i], extend='both')
+                    else: 
+                        cf = self.ax[iax].contourf(lon[i], lat[i], vartoPlot * Lfacconv[i], levels=levels_contour, transform=Lproj[i],
                                                norm=norm, vmin=Lminval[i], vmax=Lmaxval[i], cmap=Lcolormap[i])
             #  Title
             self.set_Title(self.ax, iax, Ltitle[i], Lid_overlap, Lxlab[i], Lylab[i])
@@ -691,7 +710,6 @@ class PanelPlot():
             if colorbar:
                 cb = plt.colorbar(
                     cf,
-                    extend='both', 
                     ax=self.ax[iax],
                     fraction=0.031,
                     pad=self.colorbarpad,

--- a/src/MNHPy/misc_functions.py
+++ b/src/MNHPy/misc_functions.py
@@ -213,9 +213,12 @@ def comp_altitude2DVar(oneVar3D, orography, ztop, level, n_y, n_x):
     n_x3D = copy.deepcopy(oneVar3D)
     n_y3D = copy.deepcopy(oneVar3D)
     altitude = copy.deepcopy(oneVar3D)
+    
     for i in range(len(level)):
-        n_y3D[i, :] = n_y
-        n_x3D[i, :] = n_x
+        for j in range (len(n_x)):
+            n_y3D[i, :, j] = n_y
+        for j in range(len(n_y)):
+            n_x3D[i, j] = n_x
     for i in range(oneVar3D.shape[2]):
         for j in range(oneVar3D.shape[1]):
             if ztop == 0:


### PR DESCRIPTION
Création des arguments : 
 - Larrowstep2 : liste de integer, permet de sauter des pas lors de la création de vecteurs dans un PanelPlot (si cette variable n'est pas précisée elle est initialisée à la même valeur que Larrowstep). Il est possible qu'il faille faire des concessions sur les valeurs choisies de Larrowstep et Larrowstep2 afin que les sauts d'intervalles horizontaux et verticaux soient cohérents entre eux. 
 - Lextendcolorbar : liste de booléen qui permet (ou non) d'afficher les valeurs supérieures et inférieures de la même couleur que xmin et xmax. Que deux options sont possibles, 'both' ou 'None' (par défaut) 